### PR TITLE
Implement SIMD acceleration

### DIFF
--- a/src/arch/manual.rs
+++ b/src/arch/manual.rs
@@ -1,0 +1,40 @@
+use crate::Rgba;
+
+#[allow(clippy::cast_lossless)]
+pub fn _merge_impl(original: Rgba, other: Rgba) -> Rgba {
+    // Optimize for common cases
+    if other.a == 255 {
+        return other;
+    } else if other.a == 0 {
+        return original;
+    }
+
+    let (base_r, base_g, base_b, base_a) = (
+        original.r as f32 / 255.,
+        original.g as f32 / 255.,
+        original.b as f32 / 255.,
+        original.a as f32 / 255.,
+    );
+
+    let (overlay_r, overlay_g, overlay_b, overlay_a) = (
+        other.r as f32 / 255.,
+        other.g as f32 / 255.,
+        other.b as f32 / 255.,
+        other.a as f32 / 255.,
+    );
+
+    let a_diff = 1. - overlay_a;
+    let a = a_diff.mul_add(base_a, overlay_a);
+
+    let a_ratio = a_diff * base_a;
+    let r = a_ratio.mul_add(base_r, overlay_a * overlay_r) / a;
+    let g = a_ratio.mul_add(base_g, overlay_a * overlay_g) / a;
+    let b = a_ratio.mul_add(base_b, overlay_a * overlay_b) / a;
+
+    Rgba {
+        r: (r * 255.) as u8,
+        g: (g * 255.) as u8,
+        b: (b * 255.) as u8,
+        a: (a * 255.) as u8,
+    }
+}

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -1,0 +1,17 @@
+mod aarch64;
+mod manual;
+mod x86;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use std::is_x86_feature_detected;
+
+pub fn merge_impl() -> unsafe fn(crate::Rgba, crate::Rgba) -> crate::Rgba {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("sse") && is_x86_feature_detected!("fma") {
+            return x86::_merge_impl;
+        }
+    }
+
+    manual::_merge_impl
+}

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -1,0 +1,76 @@
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "sse")]
+#[target_feature(enable = "fma")]
+pub unsafe fn _merge_impl(original: crate::pixel::Rgba, other: crate::pixel::Rgba) -> crate::pixel::Rgba {
+        // Optimize for common cases
+        if other.a == 255 {
+            return other;
+        } else if other.a == 0 {
+            return original;
+        }
+
+        let mut base = [0_f32; 4];
+
+        _mm_store_ps(
+            base.as_mut_ptr(),
+            _mm_div_ps(_mm_setr_ps(original.r as f32, original.g as f32, original.b as f32, original.a as f32), _mm_set1_ps(255.)),
+        );
+
+        let [base_r, base_g, base_b, base_a] = base;
+
+        let mut overlay = [0_f32; 4];
+
+        _mm_store_ps(
+            overlay.as_mut_ptr(),
+            _mm_div_ps(_mm_setr_ps(other.r as f32, other.g as f32, other.b as f32, other.a as f32), _mm_set1_ps(255.)),
+        );
+
+        let [overlay_r, overlay_g, overlay_b, overlay_a] = overlay;
+
+        let a_diff = 1. - overlay_a;
+
+        let mut overlay_rgba = [0_f32; 4];
+
+        _mm_store_ps(
+            overlay_rgba.as_mut_ptr(),
+            _mm_mul_ps(
+                _mm_setr_ps(overlay_r, overlay_g, overlay_b, base_a),
+                _mm_setr_ps(overlay_a, overlay_a, overlay_a, a_diff),
+            ),
+        );
+
+        let [overlay_r, overlay_g, overlay_b, a_ratio] = overlay_rgba;
+
+        let mut rgba = [0_f32; 4];
+
+        _mm_store_ps(
+            rgba.as_mut_ptr(),
+            _mm_fmadd_ps(
+                _mm_setr_ps(a_ratio, a_ratio, a_ratio, a_diff),
+                _mm_setr_ps(base_r, base_g, base_b, base_a),
+                _mm_setr_ps(overlay_r, overlay_g, overlay_b, overlay_a),
+            ),
+        );
+
+        let [r, g, b, a] = rgba;
+
+        let mut res = [0_f32; 4];
+
+        _mm_store_ps(
+            res.as_mut_ptr(),
+            _mm_mul_ps(
+                _mm_div_ps(_mm_setr_ps(r, g, b, a), _mm_setr_ps(a, a, a, 1.)),
+                _mm_set1_ps(255.),
+            ),
+        );
+
+        let [r, g, b, a] = res;
+
+        crate::pixel::Rgba { r: r as u8, g: g as u8, b: b as u8, a: a as u8 }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,8 @@ pub mod sequence;
 #[cfg(feature = "text")]
 pub mod text;
 
+mod arch;
+
 macro_rules! inline_doc {
     ($($token:item)*) => {
         $(#[doc(inline)] $token)*

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,6 +1,7 @@
 //! Encloses pixel-related traits and pixel type implementations.
 
 use crate::Error::DecodingError;
+use crate::arch;
 use crate::{
     encodings::ColorType,
     image::OverlayMode,
@@ -888,44 +889,8 @@ impl Pixel for Rgba {
         [self.r, self.g, self.b, self.a]
     }
 
-    // TODO: SIMD could speed this up significantly
-    #[allow(clippy::cast_lossless)]
     fn merge(self, other: Self) -> Self {
-        // Optimize for common cases
-        if other.a == 255 {
-            return other;
-        } else if other.a == 0 {
-            return self;
-        }
-
-        let (base_r, base_g, base_b, base_a) = (
-            self.r as f32 / 255.,
-            self.g as f32 / 255.,
-            self.b as f32 / 255.,
-            self.a as f32 / 255.,
-        );
-
-        let (overlay_r, overlay_g, overlay_b, overlay_a) = (
-            other.r as f32 / 255.,
-            other.g as f32 / 255.,
-            other.b as f32 / 255.,
-            other.a as f32 / 255.,
-        );
-
-        let a_diff = 1. - overlay_a;
-        let a = a_diff.mul_add(base_a, overlay_a);
-
-        let a_ratio = a_diff * base_a;
-        let r = a_ratio.mul_add(base_r, overlay_a * overlay_r) / a;
-        let g = a_ratio.mul_add(base_g, overlay_a * overlay_g) / a;
-        let b = a_ratio.mul_add(base_b, overlay_a * overlay_b) / a;
-
-        Self {
-            r: (r * 255.) as u8,
-            g: (g * 255.) as u8,
-            b: (b * 255.) as u8,
-            a: (a * 255.) as u8,
-        }
+        unsafe { arch::merge_impl()(self, other) }
     }
 
     #[allow(clippy::cast_lossless)]


### PR DESCRIPTION
Adds performance boosts to RIL by adding an optional `simd` feature (nightly only), which utilizes the `portable_simd` feature to bring SIMD instructions to common pixel operations.