### PR TITLE
Support gradients when rendering text

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -20,6 +20,11 @@ pub trait IntoFill: Clone + Default {
 
 /// Handles the actual filling of a shape. See [`IntoFill`] for more information.
 pub trait Fill<P: Pixel>: Clone {
+    /// Whether this fill still needs a bounding box.
+    fn needs_bounding_box(&self) -> bool {
+        false
+    }
+
     /// Sets the bounding box of the fill in place. This is used internally.
     fn set_bounding_box(&mut self, _bounding_box: BoundingBox<u32>) {}
 

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -301,7 +301,7 @@ impl<P: Pixel> IntoFill for LinearGradient<P> {
         let clone_gradient = into_colorgrad(self.colors, self.interpolation, self.blend_mode);
 
         LinearGradientFill {
-            x: 0.0,
+            x: f64::NAN, // needs_bounding_box indicator
             y: 0.0,
             tx,
             ty,
@@ -351,6 +351,11 @@ impl<P: Pixel> Clone for LinearGradientFill<P> {
 }
 
 impl<P: Pixel> Fill<P> for LinearGradientFill<P> {
+    #[inline]
+    fn needs_bounding_box(&self) -> bool {
+        self.x.is_nan()
+    }
+
     fn set_bounding_box(&mut self, (x1, y1, x2, y2): BoundingBox<u32>) {
         let width = (x2 - x1) as f64;
         let height = (y2 - y1) as f64;
@@ -501,7 +506,7 @@ impl<P: Pixel> IntoFill for RadialGradient<P> {
         RadialGradientFill {
             cx,
             cy,
-            dist: 0.0,
+            dist: f64::NAN,
             ratio: 0.0,
             position: self.position,
             cover: self.cover,
@@ -533,6 +538,11 @@ impl<P: Pixel> Clone for RadialGradientFill<P> {
 }
 
 impl<P: Pixel> Fill<P> for RadialGradientFill<P> {
+    #[inline]
+    fn needs_bounding_box(&self) -> bool {
+        self.dist.is_nan()
+    }
+
     fn set_bounding_box(&mut self, (x1, y1, x2, y2): BoundingBox<u32>) {
         let width = (x2 - x1) as f64;
         let height = (y2 - y1) as f64;

--- a/tests/test_text.rs
+++ b/tests/test_text.rs
@@ -19,3 +19,26 @@ fn test_text_rendering() -> ril::Result<()> {
     image.draw(&layout);
     image.save_inferred("tests/out/text_render_output.png")
 }
+
+#[test]
+fn test_text_gradient() -> ril::Result<()> {
+    let font = Font::open("tests/test_font_inter.ttf", 50.0)?;
+    let mut image = Image::new(600, 256, Rgba::black());
+
+    let gradient = LinearGradient::new()
+        .with_color(Rgba::new(255, 0, 0, 255))
+        .with_color(Rgba::new(0, 255, 0, 255))
+        .with_color(Rgba::new(0, 0, 255, 255));
+
+    let (cx, cy) = image.center();
+    let layout = TextLayout::new()
+        .with_wrap(WrapStyle::Word)
+        .with_width(image.width())
+        .with_position(cx, cy)
+        .with_basic_text(&font, "this is a ", Rgba::white())
+        .with_basic_text(&font, "gradient", gradient)
+        .centered();
+
+    image.draw(&layout);
+    image.save_inferred("tests/out/text_gradient_output.png")
+}


### PR DESCRIPTION
Limitations:
- much slower than just rendering a gradient masked to text
- apart from dynamic dispatch, Rust's type system does not allow for different types of fills in text layouts (e.g. `layout.with_basic_text(..., <Rgba>).with_basic_text(..., <LinearGradient>)`  will not work)

Once these limitations are resolved, they can be merged into `main`