### PR TITLE
Remove unnecessary width computation in TextLayout::height()

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -613,13 +613,12 @@ impl<'a, P: Pixel> TextLayout<'a, P> {
         self.dimensions().0
     }
 
-    /// Returns the height of the text. This is a slightly expensive operation and is not a simple
-    /// getter.
+    /// Returns the height of the text.
     ///
     /// If you want both width and height, use [`dimensions`][TextLayout::dimensions].
     #[must_use]
     pub fn height(&self) -> u32 {
-        self.dimensions().1
+        self.inner.height() as u32
     }
 
     /// Returns the bounding box of the text. Left and top bounds are inclusive; right and bottom

--- a/src/text.rs
+++ b/src/text.rs
@@ -573,13 +573,15 @@ impl<'a, P: Pixel> TextLayout<'a, P> {
         (widths, max_width, self.inner.height() as u32)
     }
 
-    /// Returns the width and height of the text. This is a slightly expensive operation and should
-    /// be used sparingly - it is not a simple getter.
+    /// Returns the width of the text. This is a slightly expensive operation and is not a simple
+    /// getter.
+    ///
+    /// If you want both width and height, use [`dimensions`][TextLayout::dimensions].
     #[must_use]
-    pub fn dimensions(&self) -> (u32, u32) {
+    pub fn width(&self) -> u32 {
         let glyphs = self.inner.glyphs();
         if glyphs.is_empty() {
-            return (0, 0);
+            return 0;
         }
 
         let mut width = 0;
@@ -601,16 +603,7 @@ impl<'a, P: Pixel> TextLayout<'a, P> {
             }
         }
 
-        (width, self.inner.height() as u32)
-    }
-
-    /// Returns the width of the text. This is a slightly expensive operation and is not a simple
-    /// getter.
-    ///
-    /// If you want both width and height, use [`dimensions`][TextLayout::dimensions].
-    #[must_use]
-    pub fn width(&self) -> u32 {
-        self.dimensions().0
+        width
     }
 
     /// Returns the height of the text.
@@ -619,6 +612,13 @@ impl<'a, P: Pixel> TextLayout<'a, P> {
     #[must_use]
     pub fn height(&self) -> u32 {
         self.inner.height() as u32
+    }
+
+    /// Returns the width and height of the text. This is a slightly expensive operation and should
+    /// be used sparingly - it is not a simple getter.
+    #[must_use]
+    pub fn dimensions(&self) -> (u32, u32) {
+        (self.width(), self.height())
     }
 
     /// Returns the bounding box of the text. Left and top bounds are inclusive; right and bottom

--- a/src/text.rs
+++ b/src/text.rs
@@ -465,7 +465,7 @@ impl<'a, P: Pixel> TextLayout<'a, P> {
         self
     }
 
-    /// Sets the wrapping width of the text. This does not impact [`Self::dimensions`].
+    /// Sets the wrapping width of the text. This does not impact [`Self::width`] and [`Self::dimensions`].
     ///
     /// **This must be set before adding any text segments!**
     #[must_use]


### PR DESCRIPTION
Hey,

This is a small PR containing improvements to the performance of `TextLayout::height()`.

The function calls the inner function `dimensions` which calculates both width and height but only height is needed. The cost of calling `dimension` to get the height is higher and depends on the length of the text. By calling the height() function on the inner `Layout` (from the fontdue crate), we reduce the overhead of `height`.

Furthermore, from a design point of view, it could be interesting to move the width calculation to the `TextLayout::width()` instead of `TextLayout::dimensions()` and then construct the pair in `dimensions` using the `width` and `height` functions. If validated, I could add this change to this PR.

(Note: this speeds up the process of find out the font size that can fit a text in a width and height constrained box).