### PR TITLE
Fix memory leaks in webp encoding

### DIFF
--- a/src/encodings/webp.rs
+++ b/src/encodings/webp.rs
@@ -160,9 +160,29 @@ impl Encoder for WebPEncoder {
             libwebp::WebPMuxSetCanvasSize(mux, sample.width() as _, sample.height() as _);
             libwebp::WebPMuxSetAnimationParams(mux, std::ptr::addr_of!(params));
 
+            let mut final_image = std::mem::zeroed::<libwebp::WebPData>();
+            let mut encoded_frames = Vec::new();
+
+            let free = |mut final_image: libwebp::WebPData, encoded_frames: Vec<libwebp::WebPData>, mux: *mut libwebp::WebPMux| {
+                libwebp::WebPDataClear(std::ptr::addr_of_mut!(final_image));
+                for mut f in encoded_frames {
+                    libwebp::WebPDataClear(std::ptr::addr_of_mut!(f));
+                }
+                libwebp::WebPMuxDelete(mux);
+            };
+
             for frame in sequence.iter() {
-                let frame = libwebp::WebPMuxFrameInfo {
-                    bitstream: self.encode_image(frame)?,
+                let encoded_frame = match self.encode_image(frame) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        free(final_image, encoded_frames, mux);
+                        return Err(e);
+                    }
+                };
+                encoded_frames.push(encoded_frame);
+
+                let frame_info = libwebp::WebPMuxFrameInfo {
+                    bitstream: encoded_frame,
                     duration: frame.delay().as_millis() as _,
                     id: libwebp::WEBP_CHUNK_ANMF,
                     dispose_method: match frame.disposal() {
@@ -172,34 +192,44 @@ impl Encoder for WebPEncoder {
                     ..std::mem::zeroed() // TODO: blend method could be configurable
                 };
 
-                libwebp::WebPMuxPushFrame(mux, std::ptr::addr_of!(frame), 0);
+                libwebp::WebPMuxPushFrame(mux, std::ptr::addr_of!(frame_info), 0);
             }
 
-            let mut data = std::mem::zeroed::<libwebp::WebPData>();
-            match libwebp::WebPMuxAssemble(mux, std::ptr::addr_of_mut!(data)) {
-                libwebp::WEBP_MUX_NOT_FOUND => return Err(Error::EmptyImageError),
+            let mux_error = libwebp::WebPMuxAssemble(mux, std::ptr::addr_of_mut!(final_image));
+            match mux_error {
+                libwebp::WEBP_MUX_OK => {}
+                libwebp::WEBP_MUX_NOT_FOUND => {
+                    free(final_image, encoded_frames, mux);
+                    return Err(Error::EmptyImageError);
+                }
                 libwebp::WEBP_MUX_INVALID_ARGUMENT => {
+                    free(final_image, encoded_frames, mux);
                     return Err(Error::EncodingError(
                         "WebP mux invalid argument".to_string(),
-                    ))
+                    ));
                 }
                 libwebp::WEBP_MUX_BAD_DATA => {
-                    return Err(Error::EncodingError("WebP mux bad data".to_string()))
+                    free(final_image, encoded_frames, mux);
+                    return Err(Error::EncodingError("WebP mux bad data".to_string()));
                 }
                 libwebp::WEBP_MUX_MEMORY_ERROR => {
-                    return Err(Error::EncodingError("WebP mux memory error".to_string()))
+                    free(final_image, encoded_frames, mux);
+                    return Err(Error::EncodingError("WebP mux memory error".to_string()));
                 }
                 libwebp::WEBP_MUX_NOT_ENOUGH_DATA => {
-                    return Err(Error::EncodingError("WebP mux not enough data".to_string()))
+                    free(final_image, encoded_frames, mux);
+                    return Err(Error::EncodingError("WebP mux not enough data".to_string()));
                 }
-                _ => (),
+                i32::MIN..=-5_i32 | 2_i32..=i32::MAX => {
+                    free(final_image, encoded_frames, mux);
+                    return Err(Error::EncodingError(format!("WebP mux error {}", mux_error)));
+                }
             };
 
-            let out = std::slice::from_raw_parts(data.bytes, data.size as _);
-            dest.write_all(out)?;
-
-            libwebp::WebPDataClear(std::ptr::addr_of_mut!(data));
-            libwebp::WebPMuxDelete(mux);
+            let data = std::slice::from_raw_parts(final_image.bytes, final_image.size);
+            let result = dest.write_all(data);
+            free(final_image, encoded_frames, mux);
+            result?;
         }
 
         Ok(())


### PR DESCRIPTION
Hi,
I noticed that long running programs which encode a lot of webp images accumulate memory very fast.  
This is my attempt at fixing these memory leaks. It's my first time working with unsafe rust, so I am not sure if I caught everything.  I used the following tests to simulate load:
```rust
#[test]
fn test_if_webp_encode_has_memory_leak() -> ril::Result<()> {
    let img = Image::new(10, 10, Rgb::new(0, 0, 0));

    let mut out = Vec::new();

    for _ in 0..100000 {
        out.clear();
        img.encode(ImageFormat::WebP, &mut out).expect("encode failed:");
    }

    Ok(())
}

#[test]
fn test_if_webp_decode_has_memory_leak() -> ril::Result<()> {
    let mut webp_bytes = Vec::new();
    Image::new(10, 10, Rgb::new(0, 0, 0))
        .encode(ImageFormat::WebP, &mut webp_bytes)
        .expect("encode failed:");

    for _ in 0..200000 {
        Image::<Dynamic>::from_bytes(ImageFormat::WebP, &webp_bytes).expect("decode failed:");
    }

    Ok(())
}

#[test]
fn test_if_animated_webp_encode_has_memory_leak() -> ril::Result<()> {
    let black = Frame::from_image(Image::new(10, 10, Rgb::black())).with_delay(Duration::from_millis(100));
    let white = Frame::from_image(Image::new(10, 10, Rgb::white())).with_delay(Duration::from_millis(100));

    let mut out = Vec::new();

    for _ in 0..100000 {
        let mut seq = ImageSequence::new();
        seq.push_frame(black.clone());
        seq.push_frame(white.clone());

        out.clear();
        seq.encode(ImageFormat::WebP, &mut out).expect("encode failed:");
    }

    Ok(())
}

#[test]
fn test_if_animated_webp_decode_has_memory_leak() -> ril::Result<()> {
    let black = Frame::from_image(Image::new(10, 10, Rgb::black())).with_delay(Duration::from_millis(100));
    let white = Frame::from_image(Image::new(10, 10, Rgb::white())).with_delay(Duration::from_millis(100));

    let mut seq = ImageSequence::new();
    seq.push_frame(black.clone());
    seq.push_frame(white.clone());

    let mut webp_bytes = Vec::new();
    seq.encode(ImageFormat::WebP, &mut webp_bytes).expect("encode failed:");

    for _ in 0..200000 {
        ImageSequence::<Dynamic>::from_bytes(ImageFormat::WebP, &webp_bytes).expect("decode failed:");
    }

    Ok(())
}
```
Without my fixes the memory consumption quickly climes to hundreds of MB for both encoding tests. With the patch applied it stays at around 10MB for me. Decoding seams to work fine.  
The most important change is the call to `libwebp::WebPDataClear` after the encoded image was written to the rust writer in [WebPEncoder.encode](https://github.com/jay3332/ril/compare/main...ydylla:ril:fix-leak?expand=1#diff-95cba604f08629e53bcde4d0b35b8b70a571c16c34fe6b5562234d6e4f81dc4bR141). I also tried to ensure the freeing is done before each return in case of an error.  

If you want I can also push the tests to [test_webp.rs](https://github.com/jay3332/ril/blob/main/tests/test_webp.rs). I was not sure if this makes sense because they do not assert anything and run for about 30 seconds. They require a human to look at the memory usage of the test runner :)