### PR TITLE
fix: use correct font for pushed segment in TextLayout

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -503,7 +503,7 @@ impl<'a, P: Pixel> TextLayout<'a, P> {
             &TextStyle::with_user_data(
                 &segment.text,
                 segment.size,
-                0,
+                self.fonts.len() - 1,
                 (segment.fill, segment.overlay),
             ),
         );


### PR DESCRIPTION
repro code:

```rust
let mut layout = TextLayout::new();
layout.push_basic_text(&font_regular, "foo", Rgba::white());
layout.push_basic_text(&font_italic, "bar", Rgba::white());

let (width, height) = layout.dimensions();
let mut img = Image::new(width, height, Rgba::black());

layout.draw(&mut img);
```

result before fix:
![before](https://github.com/jay3332/ril/assets/289746/0dc9586f-58b9-4fd7-a4d0-d50bd3398ba4)

result after fix:
![after](https://github.com/jay3332/ril/assets/289746/ba17068c-1244-470f-8692-8d693ea5d098)

i went with the simplest possible solution with the code that's there already, additional optimisations could possibly be made to reuse fonts when multiple segments use the same font.