### PR TITLE
fix: duplication when text is centered with default anchors

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -698,8 +698,12 @@ impl<'a, P: Pixel> Draw<P> for TextLayout<'a, P> {
         let image = &mut *image;
 
         // Skips the calculation of offsets
-        if self.x_anchor == HorizontalAnchor::Left && self.y_anchor == VerticalAnchor::Top {
+        if self.x_anchor == HorizontalAnchor::Left
+            && self.y_anchor == VerticalAnchor::Top
+            && self.align == TextAlign::Left
+        {
             render_layout(image, &self.fonts, &self.inner);
+            return;
         }
 
         let (widths, max_width, fx, ox, oy) = self.calculate_offsets();


### PR DESCRIPTION
repro code:

```rust
let mut layout = TextLayout::new()
    .with_align(TextAlign::Center)
    .with_wrap(WrapStyle::Word)
    .with_width(100);
layout.push_basic_text(&font, "ril is cool", Rgba::white());

let (width, height) = layout.dimensions();
let mut img = Image::new(width, height, Rgba::black());

layout.draw(&mut img);
```

result before fix:
![image](https://github.com/jay3332/ril/assets/289746/52a51b9e-1390-4b69-9d68-dd4bce59ac6c)

result after fix:
![foo](https://github.com/jay3332/ril/assets/289746/3d1b45fc-f425-495b-8e26-62169d1ad0f3)

the cause is allowing execution to fall through the shortcut `render_layout` to execute `render_layout_with_alignment` as well. i updated the shortcut to take alignment into consideration, then stopped it falling through by returning from the function.

it's possible i've missed some other edge cases with this approach, i didn't dig very deeply into how `render_layout` and `render_layout_with_alignment` work.